### PR TITLE
Component: Patched location/size of interface links.

### DIFF
--- a/src/metauml_base.mp
+++ b/src/metauml_base.mp
@@ -122,7 +122,7 @@ vardef drawCrossedCircle(text pA)(text pB)(text height) =
   pD := (width/2, -height/2 - 1);
   pD := pD rotated (alfa) shifted pA;
 
-  fill pA..pB..pA -- cycle withcolor white;
+  fill pA .. pB .. cycle withcolor white;
 
   draw pA -- pB;
   draw pC -- pD;
@@ -141,18 +141,18 @@ vardef drawSemiCircle(text pA)(text pB)(text height) =
   width = _length(pA)(pB);
 
   pair pC, pD;
-  pC := (width/2 + 5, height/2 + 1);
-  pC := pC rotated (alfa) shifted pB;
-  pD := (width/2 + 5, -height/2 - 1);
-  pD := pD rotated (alfa) shifted pB;
+  pC = (0, width) rotated (alfa) shifted pB;
+  pD = (0, -width) rotated (alfa) shifted pB;
 
   draw pC .. pA .. pD;
 enddef;
 
 vardef drawCircle(text pA)(text pB)(text height) =
-  fill pA..pB..pA -- cycle withcolor white;
+  path circ;
+  circ = pA .. 2 * pB - pA .. cycle;
 
-  draw pA .. pB .. pA;
+  fill circ withcolor white;
+  draw circ;
 enddef;
 
 vardef drawLine(expr my_path) =

--- a/src/metauml_component_relations.mp
+++ b/src/metauml_component_relations.mp
@@ -6,10 +6,10 @@ if known _metauml_component_relations_mp:
 fi;
 _metauml_component_relations_mp:=1;
 
-defaultRelationHeadWidth  := 25;
-defaultRelationHeadHeight := 10;
-requiredInterfaceHeadWidth    := 5;
-requiredInterfaceHeadHeight   := 15;
+defaultRelationHeadWidth    := 12.5;
+defaultRelationHeadHeight   := 0;
+requiredInterfaceHeadWidth  := 17.5;
+requiredInterfaceHeadHeight := 0;
 
 vardef requiredInterfaceInfo@# =
   LinkInfo@#;


### PR DESCRIPTION
Patched requiredInterface and providedInterface so that the center of the lollipop is at the point specified.
This allows for specifying the halfway point between components for a connected interface, while still looking good for closely spaced components.

[test.mp.txt](https://github.com/ogheorghies/MetaUML/files/3988383/test.mp.txt)
[test-mps-before.pdf](https://github.com/ogheorghies/MetaUML/files/3988378/test-mps-before.pdf)
[test-mps-after.pdf](https://github.com/ogheorghies/MetaUML/files/3988381/test-mps-after.pdf)
